### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -4,6 +4,8 @@ on:
    - cron: '0 5 * * *' # Runs daily at 5 AM UTC
   workflow_dispatch: #allow manual trigger
 
+permissions:
+  contents: read
 jobs:
   depCheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SPANDigital/with/security/code-scanning/2](https://github.com/SPANDigital/with/security/code-scanning/2)

To fix the problem, add a `permissions` block specifying minimal required privileges for the workflow. The most secure default is `contents: read`, which allows jobs to read repository contents but not write or modify them. Add this block at the workflow root, just after the `name` and `on` sections, so it applies to all jobs in the workflow unless overridden. The edit should only involve inserting:

```yaml
permissions:
  contents: read
```

after the existing header and triggers, on a new line before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
