### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SPANDigital/with/security/code-scanning/1](https://github.com/SPANDigital/with/security/code-scanning/1)

To fix the issue, add a `permissions` block specifying minimal privilege (`contents: read`) to the workflow or job. For the current workflow, the best practice is to place the block at the top level (directly under the workflow `name:` line), which will apply it to all jobs unless they specify something else. This prevents jobs from running with unnecessary write access. You should edit `.github/workflows/go.yml`, inserting the following block immediately under line 4:

```yaml
permissions:
  contents: read
```

No imports or definitions are required, as this is a declarative change to workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
